### PR TITLE
Implement the simplest-possible `allocate` and `deallocate`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: c
+install:
+  - wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
+  - wget https://raw.githubusercontent.com/simonjbeaumont/ocaml-travis-coveralls/master/travis-coveralls.sh
+script: bash -ex .travis-opam.sh && bash -ex travis-coveralls.sh
+sudo: required
+env:
+  global:
+    - PACKAGE="btree"
+    - OCAML_VERSION=4.02
+    - COV_CONF="oasis setup && ./configure --enable-tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ env:
   global:
     - PACKAGE="btree"
     - OCAML_VERSION=4.02
-    - COV_CONF="oasis setup && ./configure --enable-tests"
+    - COV_CONF="oasis setup && ocaml setup.ml -configure --enable-tests"

--- a/lib/heap.mli
+++ b/lib/heap.mli
@@ -43,7 +43,7 @@ module Make(Underlying: V1_LWT.BLOCK): sig
       FIXME: add this to a transaction somehow
   *)
 
-  val deallocate: block:Block.t -> unit -> unit Lwt.t
+  val deallocate: block:Block.t -> unit -> unit error Lwt.t
   (** Deallocate a block by adding it to the free list.
       FIXME: add this to a transaction somehow
   *)

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -69,7 +69,8 @@ let heap_allocate_deallocate () =
     >>= fun block ->
     let block = expect_ok_msg block in
     H.deallocate ~block:block ()
-    >>= fun () ->
+    >>= fun x ->
+    let () = expect_ok_msg x in
     Lwt.return () in
   Lwt_main.run t
 

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -53,9 +53,30 @@ let heap_connect () =
     Lwt.return () in
   Lwt_main.run t
 
+let heap_allocate_deallocate () =
+  let t =
+    Ramdisk.connect ~name:"heap"
+    >>= fun x ->
+    let from = expect_ok "Ramdisk.connect" x in
+    let module H = Heap.Make(Ramdisk) in
+    H.format ~block:from ()
+    >>= fun x ->
+    let () = expect_ok_msg x in
+    H.connect ~block:from ()
+    >>= fun h ->
+    let h = expect_ok_msg h in
+    H.allocate ~t:h ~length:1L ()
+    >>= fun block ->
+    let block = expect_ok_msg block in
+    H.deallocate ~block:block ()
+    >>= fun () ->
+    Lwt.return () in
+  Lwt_main.run t
+
 let tests = [
   "heap_format" >:: heap_format;
   "heap connect" >:: heap_connect;
+  "heap allocate-deallocate" >:: heap_allocate_deallocate;
 ]
 
 let _ =

--- a/opam
+++ b/opam
@@ -9,12 +9,14 @@ dev-repo: "https://github.com/mirage/ocaml-btree.git"
 bug-reports: "https://github.com/mirage/ocaml-btree/issues"
 
 build: [
-  ["./configure"]
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure"]
   [make]
 ]
 
 build-test:[
-  ["./configure" "--enable-tests"]
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
   [make "test"]
 ]
 install: [make "install"]
@@ -29,6 +31,7 @@ depends: [
   "lwt"
   "mirage-block"
   "ocamlfind" {build}
+  "oasis" {build}
   "ounit" {test}
 ]
 available: [ocaml-version >= "4.02.0"]


### PR DESCRIPTION
In this implementation
- `allocate`: bumps the high-water mark, or fails
- `deallocate`: if the block is the highest allocated, reduces the high-water mark, or fails
