### PR TITLE
Implement `read` and `write` on allocated blocks

### DIFF
--- a/lib/heap.ml
+++ b/lib/heap.ml
@@ -175,8 +175,13 @@ module Make(Underlying: V1_LWT.BLOCK) = struct
     let disconnect t =
       t.connected <- false;
       Lwt.return ()
-    let read _ _ _ = failwith "read"
-    let write _ _ _ = failwith "write"
+
+    let read t ofs bufs =
+      (* Data follows the header sector *)
+      Underlying.read t.heap.underlying (Int64.(add (add ofs t.offset) 1L)) bufs
+    let write t ofs bufs =
+      (* Data follows the header sector *)
+      Underlying.write t.heap.underlying (Int64.(add (add ofs t.offset) 1L)) bufs
 
     let create heap offset h =
       Underlying.get_info heap.underlying

--- a/lib/heap.ml
+++ b/lib/heap.ml
@@ -181,10 +181,11 @@ module Make(Underlying: V1_LWT.BLOCK) = struct
     let create heap offset h =
       Underlying.get_info heap.underlying
       >>= fun info ->
+      let size_sectors = Int64.(div (pred (add h.Allocated_block.length (of_int info.Underlying.sector_size))) (of_int info.Underlying.sector_size)) in
       let info = {
         read_write = info.Underlying.read_write;
         sector_size = info.Underlying.sector_size;
-        size_sectors = info.Underlying.size_sectors;
+        size_sectors = size_sectors;
       } in
       Lwt.return {
         heap;


### PR DESCRIPTION
This is a very simple implementation which relies on the fact that all allocated `BLOCK`s are contiguous on the underlying disk.
