### PR TITLE
Heap API now allocates + registers a reference somewhere

### DIFF
--- a/lib/btree_s.mli
+++ b/lib/btree_s.mli
@@ -57,7 +57,7 @@ module type TREE = sig
   type element
   type block
 
-  val create: block -> t error Lwt.t
+  val create: block:block -> d:int -> unit -> t error Lwt.t
   val connect: block -> t error Lwt.t
 
   val insert: t -> element -> t error Lwt.t

--- a/lib/heap.ml
+++ b/lib/heap.ml
@@ -144,7 +144,7 @@ module Allocated_block(B: V1_LWT.BLOCK) = struct
     set_hdr_deleted sector (if t.deleted then 1 else 2);
     set_hdr_tag sector (int_of_tag t.tag);
     let open Error.FromBlock in
-    B.write block 0L [ sector ]
+    B.write block offset [ sector ]
     >>= fun () ->
     Lwt.return (`Ok ())
 end

--- a/lib/heap.ml
+++ b/lib/heap.ml
@@ -190,23 +190,23 @@ module Make(Underlying: V1_LWT.BLOCK) = struct
       Lwt.return (`Ok (offset, h))
     end
 
-    let deallocate ~heap ~offset ~h () =
-      (* Mark the block as deleted to help detect use-after-free bugs *)
-      let h = { h with Allocated_block.deleted = true } in
-      let open Error.Infix in
-      Allocated_block.write ~block:heap.underlying ~offset h
-      >>= fun () ->
-      (* If this block is the highest allocated block, then decrease the low
-         water mark *)
-      let sector_size = heap.info.sector_size in
-      let length_sectors = (Int64.to_int h.Allocated_block.length + sector_size - 1) / sector_size + 1 in
-      if Int64.(add offset (of_int length_sectors)) = heap.root_block.Root_block.high_water_mark then begin
-        heap.root_block <- { heap.root_block with Root_block.high_water_mark = offset };
-        Root_block.write ~block:heap.underlying heap.root_block
-      end else begin
-        (* Add the blocks to the free list *)
-        failwith "unimplemented: deallocate"
-      end
+  let deallocate ~heap ~offset ~h () =
+    (* Mark the block as deleted to help detect use-after-free bugs *)
+    let h = { h with Allocated_block.deleted = true } in
+    let open Error.Infix in
+    Allocated_block.write ~block:heap.underlying ~offset h
+    >>= fun () ->
+    (* If this block is the highest allocated block, then decrease the low
+       water mark *)
+    let sector_size = heap.info.sector_size in
+    let length_sectors = (Int64.to_int h.Allocated_block.length + sector_size - 1) / sector_size + 1 in
+    if Int64.(add offset (of_int length_sectors)) = heap.root_block.Root_block.high_water_mark then begin
+      heap.root_block <- { heap.root_block with Root_block.high_water_mark = offset };
+      Root_block.write ~block:heap.underlying heap.root_block
+    end else begin
+      (* Add the blocks to the free list *)
+      failwith "unimplemented: deallocate"
+    end
 
   type reference = int64
 

--- a/lib/heap.ml
+++ b/lib/heap.ml
@@ -45,7 +45,7 @@ module Root_block(B: V1_LWT.BLOCK) = struct
     free_list: int64; (* reference to the first block on the free list *)
   } with sexp
 
-  let create () = { magic; version = 0l; root = 0L; high_water_mark = 0L; free_list = 0L }
+  let create () = { magic; version = 0l; root = 0L; high_water_mark = 1L; free_list = 0L }
 
   let read ~block =
     B.get_info block

--- a/lib/heap.mli
+++ b/lib/heap.mli
@@ -93,3 +93,6 @@ module Make(Underlying: V1_LWT.BLOCK): sig
   (** [root heap ()] returns the root reference block *)
 
 end
+
+val alloc: int -> Cstruct.t
+(** [alloc n] allocate a page-aligned buffer of length [n] *)

--- a/lib/heap.mli
+++ b/lib/heap.mli
@@ -55,17 +55,14 @@ module Make(Underlying: V1_LWT.BLOCK): sig
   module Refs: sig
     type t
 
-    val allocate: heap:heap -> length:int -> unit -> t error Lwt.t
-    (** Allocate a reference block containing up to [length] references to
-        other blocks.
-        FIXME: add this to a transaction somehow
-    *)
+    val allocate: t:t -> index:int -> length:int -> unit -> t error Lwt.t
+    (** Allocate a child reference block and set a reference to it from
+        [t] at array index [index]. The created block will be of length
+        [length] references. *)
 
     val deallocate: t:t -> unit -> unit error Lwt.t
-    (** Deallocate a block by adding it to the free list.
-        FIXME: add this to a transaction somehow
-    *)
-
+    (** Mark a reference block as unused so that it may be garbage collected. *)
+    
     val ref: t -> reference
     (** Return a reference to the block *)
 

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -65,7 +65,10 @@ let heap_allocate_deallocate () =
     H.connect ~block:from ()
     >>= fun h ->
     let h = expect_ok_msg h in
-    H.Bytes.allocate ~heap:h ~length:1L ()
+    H.root ~heap:h ()
+    >>= fun root ->
+    let root = expect_ok_msg root in
+    H.Bytes.allocate ~parent:root ~index:0 ~length:1L ()
     >>= fun block ->
     let block = expect_ok_msg block in
     H.Bytes.deallocate ~t:block ()
@@ -87,10 +90,13 @@ let heap_write_read () =
     >>= fun h ->
     let h = expect_ok_msg h in
     (* Allocate 2 blocks *)
-    H.Bytes.allocate ~heap:h ~length:1L ()
+    H.root ~heap:h ()
+    >>= fun root ->
+    let root = expect_ok_msg root in
+    H.Bytes.allocate ~parent:root ~index:0 ~length:1L ()
     >>= fun block1 ->
     let bytes1 = expect_ok_msg block1 in
-    H.Bytes.allocate ~heap:h ~length:1L ()
+    H.Bytes.allocate ~parent:root ~index:2 ~length:1L ()
     >>= fun block2 ->
     let bytes2 = expect_ok_msg block2 in
     (* Fill block1 with random data *)

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -134,7 +134,7 @@ let tree_create () =
     >>= fun x ->
     let block = expect_ok "Ramdisk.connect" x in
     let module T = Btree.Make(Ramdisk)(StringElement) in
-    T.create block
+    T.create ~block ~d:2 ()
     >>= fun t ->
     let _ = expect_ok "T.create" t in
     Lwt.return () in


### PR DESCRIPTION
To make the API easier to use safely, the allocate functions will take care of storing a reference to the newly-allocated block in a referring block. The idea is to make it easier to build up structures which will be reachable by the GC.
